### PR TITLE
HIR-25 feat: 사용자의 ID와 비밀번호를 받아 JWT 토큰을 생성하는 API를 구현한다.

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -39,4 +39,4 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
           JASYPT_DEFAULT_PASSWORD: ${{ secrets.JASYPT_ENCRYPTOR_PASSWORD }}
-        run: ./gradlew compileJava sonar --info
+        run: ./gradlew compileJava jacocoTestReport sonar --info

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ dependencies {
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
 
+    compileOnly 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'

--- a/build.gradle
+++ b/build.gradle
@@ -125,5 +125,6 @@ jacocoTestCoverageVerification {
 sonar {
     properties {
         property "sonar.projectKey", "jobflearn"
+        property "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ jacocoTestCoverageVerification {
                               '**/*Builder.class',
                               '**/config/**/*',
                               '**/domain/**/*',
+                              '**/dto/**/*'
                     ])
         }))
     }

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.0'
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
     id "org.sonarqube" version "3.5.0.2730"
+    id 'jacoco'
 }
 
 group = 'kr.binarybard'
@@ -52,11 +53,73 @@ dependencies {
 tasks.named('test') {
     outputs.dir snippetsDir
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
 }
 
 tasks.named('asciidoctor') {
     inputs.dir snippetsDir
     dependsOn test
+}
+
+jacocoTestReport {
+    dependsOn test
+    finalizedBy jacocoTestCoverageVerification
+
+    reports {
+        html.enabled true
+        xml.enabled true
+        csv.enabled false
+
+        html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
+    }
+}
+
+jacocoTestCoverageVerification {
+    dependsOn jacocoTestReport
+
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.5
+            }
+        }
+
+        rule {
+            enabled = true
+
+            element = 'CLASS'
+
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+        }
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it,
+                    exclude: ['**/*Application.class',
+                              '**/*Config.class',
+                              '**/*Response.class',
+                              '**/*Request.class',
+                              '**/*Mapper.class',
+                              '**/*MapperImpl.class',
+                              '**/*Exception.class',
+                              '**/*Entity.class',
+                              '**/*Builder.class',
+                              '**/config/**/*',
+                              '**/domain/**/*',
+                    ])
+        }))
+    }
 }
 
 sonar {

--- a/src/main/java/kr/binarybard/hireo/api/auth/controller/AuthenticationApiController.java
+++ b/src/main/java/kr/binarybard/hireo/api/auth/controller/AuthenticationApiController.java
@@ -1,0 +1,85 @@
+package kr.binarybard.hireo.api.auth.controller;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import kr.binarybard.hireo.api.auth.dto.RefreshTokenRequest;
+import kr.binarybard.hireo.api.auth.dto.SignInRequest;
+import kr.binarybard.hireo.api.auth.service.RefreshTokenService;
+import kr.binarybard.hireo.config.jwt.JwtTokenProvider;
+import kr.binarybard.hireo.web.auth.service.LoginService;
+import kr.binarybard.hireo.web.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthenticationApiController {
+	private final JwtTokenProvider tokenProvider;
+	private final AuthenticationManagerBuilder authenticationManagerBuilder;
+	private final LoginService loginService;
+	private final RefreshTokenService refreshTokenService;
+
+	@PostMapping("/login")
+	public ResponseEntity<JwtTokens> authorize(@Valid @RequestBody SignInRequest request) {
+		var authentication = authenticate(request.getEmail(), request.getPassword());
+		return ResponseEntity.ok().body(generateJwtTokens(request.getEmail(), authentication));
+	}
+
+	@PostMapping("/reissue")
+	public ResponseEntity<JwtTokens> reissue(@Valid @RequestBody RefreshTokenRequest request) {
+		String currentRefreshToken = request.getRefreshToken();
+
+		validateRefreshToken(currentRefreshToken);
+
+		String username = tokenProvider.getUsernameFromToken(currentRefreshToken);
+
+		var userDetails = loginService.loadUserByUsername(username);
+		var authentication = new UsernamePasswordAuthenticationToken(
+			userDetails, null, userDetails.getAuthorities());
+
+		return ResponseEntity.ok().body(generateJwtTokens(username, authentication));
+	}
+
+	private JwtTokens generateJwtTokens(String username, Authentication authentication) {
+		String accessToken = tokenProvider.createAccessToken(authentication);
+		String refreshToken = createAndSaveRefreshToken(username, authentication);
+
+		return new JwtTokens(accessToken, refreshToken);
+	}
+
+	private Authentication authenticate(String email, String password) {
+		var authenticationToken = new UsernamePasswordAuthenticationToken(email, password);
+		var authentication = authenticationManagerBuilder.getObject()
+			.authenticate(authenticationToken);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+		return authentication;
+	}
+
+	private String createAndSaveRefreshToken(String email, Authentication authentication) {
+		String refreshToken = tokenProvider.createRefreshToken(authentication);
+
+		refreshTokenService.deleteTokenByEmail(email);
+		refreshTokenService.save(email, refreshToken);
+
+		return refreshToken;
+	}
+
+	private void validateRefreshToken(String token) {
+		if (!refreshTokenService.validateToken(token)) {
+			throw new RuntimeException("Refresh token is invalid");
+		}
+	}
+
+	private record JwtTokens(@JsonProperty("access_token") String accessToken,
+							 @JsonProperty("refresh_token") String refreshToken) {
+	}
+}

--- a/src/main/java/kr/binarybard/hireo/api/auth/domain/RefreshToken.java
+++ b/src/main/java/kr/binarybard/hireo/api/auth/domain/RefreshToken.java
@@ -1,0 +1,34 @@
+package kr.binarybard.hireo.api.auth.domain;
+
+import jakarta.persistence.*;
+import kr.binarybard.hireo.web.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Getter
+@Entity(name = "refresh_tokens")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@OneToOne
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	private String token;
+
+	private Instant expiryDate;
+
+	@Builder
+	public RefreshToken(Member member, String token, Instant expiryDate) {
+		this.member = member;
+		this.token = token;
+		this.expiryDate = expiryDate;
+	}
+}

--- a/src/main/java/kr/binarybard/hireo/api/auth/dto/RefreshTokenRequest.java
+++ b/src/main/java/kr/binarybard/hireo/api/auth/dto/RefreshTokenRequest.java
@@ -1,0 +1,19 @@
+package kr.binarybard.hireo.api.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RefreshTokenRequest {
+	@NotEmpty
+	@JsonProperty("refresh_token")
+	private String refreshToken;
+
+	@Builder
+	public RefreshTokenRequest(String refreshToken) {
+		this.refreshToken = refreshToken;
+	}
+}

--- a/src/main/java/kr/binarybard/hireo/api/auth/dto/SignInRequest.java
+++ b/src/main/java/kr/binarybard/hireo/api/auth/dto/SignInRequest.java
@@ -1,0 +1,28 @@
+package kr.binarybard.hireo.api.auth.dto;
+
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@Setter
+public class SignInRequest {
+	@NotEmpty
+	@Email
+	@Length(max = 32)
+	private String email;
+
+	@NotEmpty
+	@Length(min = 8, max = 20)
+	private String password;
+
+	@Builder
+	public SignInRequest(String email, String password) {
+		this.email = email;
+		this.password = password;
+	}
+}

--- a/src/main/java/kr/binarybard/hireo/api/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/kr/binarybard/hireo/api/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,15 @@
+package kr.binarybard.hireo.api.auth.repository;
+
+import kr.binarybard.hireo.api.auth.domain.RefreshToken;
+import kr.binarybard.hireo.web.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+	Optional<RefreshToken> findByMemberAndToken(Member member, String token);
+
+	Long deleteByMember(Member member);
+}

--- a/src/main/java/kr/binarybard/hireo/api/auth/service/RefreshTokenService.java
+++ b/src/main/java/kr/binarybard/hireo/api/auth/service/RefreshTokenService.java
@@ -1,0 +1,73 @@
+package kr.binarybard.hireo.api.auth.service;
+
+import jakarta.transaction.Transactional;
+import kr.binarybard.hireo.api.auth.domain.RefreshToken;
+import kr.binarybard.hireo.api.auth.repository.RefreshTokenRepository;
+import kr.binarybard.hireo.config.jwt.JwtTokenProvider;
+import kr.binarybard.hireo.web.member.domain.Member;
+import kr.binarybard.hireo.web.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.Base64;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+	private final RefreshTokenRepository refreshTokenRepository;
+	private final JwtTokenProvider tokenProvider;
+	private final MemberService memberService;
+
+	@Transactional
+	public void deleteTokenByEmail(String email) {
+		refreshTokenRepository.deleteByMember(memberService.findByEmail(email));
+	}
+
+	@Transactional
+	public Long save(String email, String token) {
+		var refreshToken = RefreshToken.builder()
+			.member(memberService.findByEmail(email))
+			.token(hashToken(token))
+			.expiryDate(Instant.now().plusMillis(tokenProvider.REFRESH_TOKEN_EXPIRE_TIME))
+			.build();
+		return refreshTokenRepository.save(refreshToken).getId();
+	}
+
+	private String hashToken(String token) {
+		try {
+			MessageDigest md = MessageDigest.getInstance("SHA-256");
+			byte[] hash = md.digest(token.getBytes(StandardCharsets.UTF_8));
+			return Base64.getEncoder().encodeToString(hash);
+		} catch (NoSuchAlgorithmException e) {
+			throw new RuntimeException("SHA-256 is not a valid algorithm", e);
+		}
+	}
+
+	public boolean validateToken(String token) {
+		return isTokenValid(token) && isTokenStored(token) && isTokenNotExpired(token);
+	}
+
+	private boolean isTokenValid(String token) {
+		return tokenProvider.validateToken(token);
+	}
+
+	private boolean isTokenStored(String token) {
+		String username = tokenProvider.getUsernameFromToken(token);
+		Member member = memberService.findByEmail(username);
+		var refreshToken = refreshTokenRepository.findByMemberAndToken(member, hashToken(token));
+		return refreshToken.isPresent();
+	}
+
+	private boolean isTokenNotExpired(String token) {
+		String username = tokenProvider.getUsernameFromToken(token);
+		Member member = memberService.findByEmail(username);
+		var refreshToken = refreshTokenRepository.findByMemberAndToken(member, hashToken(token));
+		return refreshToken
+			.filter(value -> !value.getExpiryDate().isBefore(Instant.now()))
+			.isPresent();
+	}
+}

--- a/src/main/java/kr/binarybard/hireo/config/SecurityConfig.java
+++ b/src/main/java/kr/binarybard/hireo/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import kr.binarybard.hireo.config.oauth.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -34,6 +35,21 @@ public class SecurityConfig {
 	}
 
 	@Bean
+	@Order(1)
+	public SecurityFilterChain restApiFilterChain(final HttpSecurity http) throws Exception {
+		return http
+			.securityMatcher("/api/**")
+			.csrf(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers("/api/auth/**").permitAll()
+				.anyRequest().authenticated())
+			.sessionManagement(session -> session
+				.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.build();
+	}
+
+	@Bean
+	@Order(2)
 	public SecurityFilterChain formFilterChain(final HttpSecurity http) throws Exception {
 		return http
 			.csrf(AbstractHttpConfigurer::disable)

--- a/src/main/java/kr/binarybard/hireo/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/kr/binarybard/hireo/config/jwt/JwtTokenProvider.java
@@ -1,9 +1,6 @@
 package kr.binarybard.hireo.config.jwt;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
@@ -14,7 +11,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;

--- a/src/main/java/kr/binarybard/hireo/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/kr/binarybard/hireo/config/jwt/JwtTokenProvider.java
@@ -1,0 +1,131 @@
+package kr.binarybard.hireo.config.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.sql.Date;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+	private static final String AUTHORITIES_KEY = "auth";
+	private Key key;
+
+	private final String base64Secret;
+	public final long REFRESH_TOKEN_EXPIRE_TIME;
+	public final long ACCESS_TOKEN_EXPIRE_TIME;
+
+	public JwtTokenProvider(
+		@Value("${security.jwt.base64-secret}") String base64Secret,
+		@Value("${security.jwt.refresh-expiration-time}") long refreshExpirationTime,
+		@Value("${security.jwt.access-expiration-time}") long accessExpirationTime
+	) {
+		this.base64Secret = base64Secret;
+		this.REFRESH_TOKEN_EXPIRE_TIME = refreshExpirationTime;
+		this.ACCESS_TOKEN_EXPIRE_TIME = accessExpirationTime;
+	}
+
+	/**
+	 * 사용자가 인증에 성공하면 토큰을 발급한다. 주어진 클레임과 주체(토큰에서 사용자에 대한 식별값)를
+	 * 가지고 토큰을 만든다.
+	 *
+	 * @param authentication 인증 정보
+	 * @return 토큰
+	 */
+	public String createToken(Authentication authentication, long expirationTime) {
+		String authorities = authentication.getAuthorities().stream()
+			.map(GrantedAuthority::getAuthority)
+			.collect(Collectors.joining(","));
+		return Jwts.builder()
+			.setSubject(authentication.getName())
+			.claim(AUTHORITIES_KEY, authorities)
+			.setIssuedAt(new Date(System.currentTimeMillis()))
+			.setExpiration(new Date(System.currentTimeMillis() + expirationTime))
+			.signWith(key, SignatureAlgorithm.HS512)
+			.compact();
+	}
+
+	public String createAccessToken(Authentication authentication) {
+		return createToken(authentication, ACCESS_TOKEN_EXPIRE_TIME);
+	}
+
+	public String createRefreshToken(Authentication authentication) {
+		return createToken(authentication, REFRESH_TOKEN_EXPIRE_TIME);
+	}
+
+	public String getUsernameFromToken(String token) {
+		return getAllClaimsFromToken(token)
+			.getBody()
+			.getSubject();
+	}
+
+	@PostConstruct
+	public void init() {
+		byte[] secretKeyBytes = Decoders.BASE64.decode(base64Secret);
+		this.key = Keys.hmacShaKeyFor(secretKeyBytes);
+	}
+
+	public Authentication getAuthentication(String token) {
+		Claims claims = getAllClaimsFromToken(token).getBody();
+		Collection<? extends GrantedAuthority> authorities =
+			Arrays.stream(Optional.ofNullable(claims.get(AUTHORITIES_KEY))
+					.map(Object::toString)
+					.orElse("")
+					.split(","))
+				.map(String::trim)
+				.filter(auth -> !auth.isEmpty())
+				.map(SimpleGrantedAuthority::new)
+				.collect(Collectors.toList());
+		User principal = new User(claims.getSubject(), "", authorities);
+		return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+	}
+
+
+	/**
+	 * 토큰이 유효한지 검증한다.
+	 *
+	 * @param token 토큰
+	 * @return 유효하면 true, 아니면 false
+	 */
+	public boolean validateToken(String token) {
+		try {
+			getAllClaimsFromToken(token);
+			return true;
+		} catch (JwtException ex) {
+			log.trace("Invalid JWT token trace: {}", ex.toString());
+			return false;
+		}
+	}
+
+	/**
+	 * 토큰에서 모든 클레임(claims)을 가져온다.
+	 *
+	 * @param token 토큰
+	 * @return 클레임
+	 */
+	private Jws<Claims> getAllClaimsFromToken(String token) {
+		return Jwts.parserBuilder()
+			.setSigningKey(key)
+			.build()
+			.parseClaimsJws(token);
+	}
+}

--- a/src/main/java/kr/binarybard/hireo/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/kr/binarybard/hireo/config/jwt/JwtTokenProvider.java
@@ -94,7 +94,7 @@ public class JwtTokenProvider {
 				.map(String::trim)
 				.filter(auth -> !auth.isEmpty())
 				.map(SimpleGrantedAuthority::new)
-				.collect(Collectors.toList());
+				.toList();
 		User principal = new User(claims.getSubject(), "", authorities);
 		return new UsernamePasswordAuthenticationToken(principal, token, authorities);
 	}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,3 +37,10 @@ jasypt:
     algorithm: PBEWithMD5AndDES
     iv-generator-classname: org.jasypt.iv.NoIvGenerator
     password: ${JASYPT_DEFAULT_PASSWORD}
+
+security:
+  jwt:
+    access-expiration-time: 86400000
+    refresh-expiration-time: 604800000
+    base64-secret: ENC(pMCfBtvxA+VV4S6cDjAokWd0z0Qr883sMgCOEB6fjeJbL84smdB9NnUj+NO2SiTqBUoM4LPjbw15Yxv+3tg0uBHHmH7X0E9JGtUmIhHoXEwQxc/Izw30z99On6j/DalJ5XSfSTdERxs=)
+

--- a/src/test/java/kr/binarybard/hireo/api/auth/controller/AuthenticationApiControllerTest.java
+++ b/src/test/java/kr/binarybard/hireo/api/auth/controller/AuthenticationApiControllerTest.java
@@ -1,0 +1,116 @@
+package kr.binarybard.hireo.api.auth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import kr.binarybard.hireo.api.auth.dto.RefreshTokenRequest;
+import kr.binarybard.hireo.api.auth.dto.SignInRequest;
+import kr.binarybard.hireo.api.auth.repository.RefreshTokenRepository;
+import kr.binarybard.hireo.web.auth.dto.SignUpRequest;
+import kr.binarybard.hireo.web.member.repository.MemberRepository;
+import kr.binarybard.hireo.web.member.service.MemberService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AuthenticationApiControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private MemberService memberService;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private RefreshTokenRepository refreshTokenRepository;
+
+	private final String username = "testuser@test.com";
+	private final String password = "testPassword123";
+
+	@BeforeEach
+	public void setUp() {
+		refreshTokenRepository.deleteAll();
+		memberRepository.deleteAll();
+
+		SignUpRequest signUpRequest = SignUpRequest.builder()
+			.email(username)
+			.password(password)
+			.build();
+		memberService.save(signUpRequest);
+	}
+
+	@DisplayName("로그인을 성공적으로 수행한다.")
+	@Test
+	public void testAuthorize() throws Exception {
+		SignInRequest signInRequest = SignInRequest.builder()
+			.email(username)
+			.password(password)
+			.build();
+
+		mockMvc.perform(post("/api/auth/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(signInRequest)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.access_token").isNotEmpty())
+			.andExpect(jsonPath("$.refresh_token").isNotEmpty());
+	}
+
+	@Test
+	@DisplayName("잘못된 비밀번호로 로그인을 시도하면 실패한다.")
+	public void loginFailDueToWrongPassword() throws Exception {
+		SignInRequest request = SignInRequest.builder()
+			.email(username)
+			.password(password + "wrong")
+			.build();
+
+		mockMvc.perform(post("/api/auth/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isForbidden());
+	}
+
+	@DisplayName("리프레시 토큰으로 새로운 토큰을 성공적으로 발급한다.")
+	@Test
+	public void testReissue() throws Exception {
+		SignInRequest signInRequest = SignInRequest.builder()
+			.email(username)
+			.password(password)
+			.build();
+
+		MvcResult result = mockMvc.perform(post("/api/auth/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(signInRequest)))
+			.andReturn();
+
+		String response = result.getResponse().getContentAsString();
+		String refreshToken = JsonPath.read(response, "$.refresh_token");
+
+		RefreshTokenRequest refreshTokenRequest = RefreshTokenRequest.builder()
+			.refreshToken(refreshToken)
+			.build();
+
+		mockMvc.perform(post("/api/auth/reissue")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(refreshTokenRequest)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.access_token").isNotEmpty())
+			.andExpect(jsonPath("$.refresh_token").isNotEmpty());
+	}
+}

--- a/src/test/java/kr/binarybard/hireo/api/auth/controller/AuthenticationApiControllerTest.java
+++ b/src/test/java/kr/binarybard/hireo/api/auth/controller/AuthenticationApiControllerTest.java
@@ -58,7 +58,7 @@ class AuthenticationApiControllerTest {
 
 	@DisplayName("로그인을 성공적으로 수행한다.")
 	@Test
-	public void testAuthorize() throws Exception {
+	void testAuthorize() throws Exception {
 		SignInRequest signInRequest = SignInRequest.builder()
 			.email(username)
 			.password(password)
@@ -74,7 +74,7 @@ class AuthenticationApiControllerTest {
 
 	@Test
 	@DisplayName("잘못된 비밀번호로 로그인을 시도하면 실패한다.")
-	public void loginFailDueToWrongPassword() throws Exception {
+	void loginFailDueToWrongPassword() throws Exception {
 		SignInRequest request = SignInRequest.builder()
 			.email(username)
 			.password(password + "wrong")
@@ -88,7 +88,7 @@ class AuthenticationApiControllerTest {
 
 	@DisplayName("리프레시 토큰으로 새로운 토큰을 성공적으로 발급한다.")
 	@Test
-	public void testReissue() throws Exception {
+	void testReissue() throws Exception {
 		SignInRequest signInRequest = SignInRequest.builder()
 			.email(username)
 			.password(password)

--- a/src/test/java/kr/binarybard/hireo/api/auth/service/RefreshTokenServiceTest.java
+++ b/src/test/java/kr/binarybard/hireo/api/auth/service/RefreshTokenServiceTest.java
@@ -1,0 +1,123 @@
+package kr.binarybard.hireo.api.auth.service;
+
+import kr.binarybard.hireo.api.auth.domain.RefreshToken;
+import kr.binarybard.hireo.api.auth.repository.RefreshTokenRepository;
+import kr.binarybard.hireo.config.jwt.JwtTokenProvider;
+import kr.binarybard.hireo.web.member.domain.Member;
+import kr.binarybard.hireo.web.member.service.MemberService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenServiceTest {
+
+	@Mock
+	private RefreshTokenRepository refreshTokenRepository;
+
+	@Mock
+	private JwtTokenProvider jwtTokenProvider;
+
+	@Mock
+	private MemberService memberService;
+
+	@InjectMocks
+	private RefreshTokenService refreshTokenService;
+
+	private String validToken;
+	private String username;
+	private Member member;
+	private RefreshToken refreshToken;
+
+	@BeforeEach
+	public void setup() {
+		validToken = "valid_token";
+		username = "username";
+		member = Member.builder()
+			.email(username)
+			.build();
+		refreshToken = RefreshToken.builder()
+			.expiryDate(Instant.now().plusMillis(10000))
+			.build();
+	}
+
+	@Test
+	@DisplayName("토큰이 유효하고 DB에 존재할 경우, validateToken은 true를 반환한다.")
+	public void testValidateToken_success() {
+		// given
+		given(jwtTokenProvider.validateToken(validToken)).willReturn(true);
+		given(jwtTokenProvider.getUsernameFromToken(validToken)).willReturn(username);
+		given(memberService.findByEmail(username)).willReturn(member);
+		given(refreshTokenRepository.findByMemberAndToken(any(Member.class), anyString()))
+			.willReturn(Optional.of(refreshToken));
+
+		// when
+		boolean result = refreshTokenService.validateToken(validToken);
+
+		// then
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("토큰이 유효하지 않을 경우, validateToken은 false를 반환한다.")
+	public void testValidateToken_withInvalidToken() {
+		// given
+		String invalidToken = "invalid_token";
+		given(jwtTokenProvider.validateToken(invalidToken)).willReturn(false);
+
+		// when
+		boolean result = refreshTokenService.validateToken(invalidToken);
+
+		// then
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	@DisplayName("토큰이 DB에서 찾을 수 없을 경우, validateToken은 false를 반환한다.")
+	public void testValidateToken_tokenNotFoundInDB() {
+		// given
+		given(jwtTokenProvider.validateToken(validToken)).willReturn(true);
+		given(jwtTokenProvider.getUsernameFromToken(validToken)).willReturn(username);
+		given(memberService.findByEmail(username)).willReturn(member);
+		given(refreshTokenRepository.findByMemberAndToken(any(Member.class), anyString()))
+			.willReturn(Optional.empty());
+
+		// when
+		boolean result = refreshTokenService.validateToken(validToken);
+
+		// then
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	@DisplayName("토큰이 만료되었을 경우, validateToken은 false를 반환한다.")
+	public void testValidateToken_tokenExpired() {
+		// given
+		RefreshToken expiredToken = RefreshToken.builder()
+			.expiryDate(Instant.now().minusMillis(10000))
+			.build();
+		given(jwtTokenProvider.validateToken(validToken)).willReturn(true);
+		given(jwtTokenProvider.getUsernameFromToken(validToken)).willReturn(username);
+		given(memberService.findByEmail(username)).willReturn(member);
+		given(refreshTokenRepository.findByMemberAndToken(any(Member.class), anyString()))
+			.willReturn(Optional.of(expiredToken));
+
+		// when
+		boolean result = refreshTokenService.validateToken(validToken);
+
+		// then
+		assertThat(result).isFalse();
+	}
+}

--- a/src/test/java/kr/binarybard/hireo/api/auth/service/RefreshTokenServiceTest.java
+++ b/src/test/java/kr/binarybard/hireo/api/auth/service/RefreshTokenServiceTest.java
@@ -55,7 +55,7 @@ class RefreshTokenServiceTest {
 
 	@Test
 	@DisplayName("토큰이 유효하고 DB에 존재할 경우, validateToken은 true를 반환한다.")
-	public void testValidateToken_success() {
+	void testValidateToken_success() {
 		// given
 		given(jwtTokenProvider.validateToken(validToken)).willReturn(true);
 		given(jwtTokenProvider.getUsernameFromToken(validToken)).willReturn(username);
@@ -72,7 +72,7 @@ class RefreshTokenServiceTest {
 
 	@Test
 	@DisplayName("토큰이 유효하지 않을 경우, validateToken은 false를 반환한다.")
-	public void testValidateToken_withInvalidToken() {
+	void testValidateToken_withInvalidToken() {
 		// given
 		String invalidToken = "invalid_token";
 		given(jwtTokenProvider.validateToken(invalidToken)).willReturn(false);
@@ -86,7 +86,7 @@ class RefreshTokenServiceTest {
 
 	@Test
 	@DisplayName("토큰이 DB에서 찾을 수 없을 경우, validateToken은 false를 반환한다.")
-	public void testValidateToken_tokenNotFoundInDB() {
+	void testValidateToken_tokenNotFoundInDB() {
 		// given
 		given(jwtTokenProvider.validateToken(validToken)).willReturn(true);
 		given(jwtTokenProvider.getUsernameFromToken(validToken)).willReturn(username);
@@ -103,7 +103,7 @@ class RefreshTokenServiceTest {
 
 	@Test
 	@DisplayName("토큰이 만료되었을 경우, validateToken은 false를 반환한다.")
-	public void testValidateToken_tokenExpired() {
+	void testValidateToken_tokenExpired() {
 		// given
 		RefreshToken expiredToken = RefreshToken.builder()
 			.expiryDate(Instant.now().minusMillis(10000))

--- a/src/test/java/kr/binarybard/hireo/utils/ConvertUtilsTest.java
+++ b/src/test/java/kr/binarybard/hireo/utils/ConvertUtilsTest.java
@@ -1,0 +1,31 @@
+package kr.binarybard.hireo.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConvertUtilsTest {
+
+	@Test
+	void testUncheckedCast() {
+		String original = "test";
+
+		String result = ConvertUtils.uncheckedCast(original);
+
+		assertEquals(original, result);
+	}
+
+	@Test
+	void testPrivateConstructor() throws NoSuchMethodException {
+		Constructor<ConvertUtils> constructor = ConvertUtils.class.getDeclaredConstructor();
+		assertTrue(Modifier.isPrivate(constructor.getModifiers()));
+
+		constructor.setAccessible(true);
+
+		assertThrows(InvocationTargetException.class, constructor::newInstance);
+	}
+}

--- a/src/test/java/kr/binarybard/hireo/web/auth/controller/LoginControllerTest.java
+++ b/src/test/java/kr/binarybard/hireo/web/auth/controller/LoginControllerTest.java
@@ -1,5 +1,7 @@
 package kr.binarybard.hireo.web.auth.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -8,11 +10,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
+import kr.binarybard.hireo.exception.DuplicateEmailException;
+import kr.binarybard.hireo.web.member.service.MemberService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -23,9 +28,12 @@ class LoginControllerTest {
 	@Autowired
 	private MockMvc mockMvc;
 
+	@MockBean
+	private MemberService memberService;
+
 	@Test
 	@DisplayName("회원가입 폼 요청")
-	public void registerFormTest() throws Exception {
+	void registerFormTest() throws Exception {
 		mockMvc.perform(get("/auth/new"))
 			.andDo(print())
 			.andExpect(status().isOk())
@@ -35,7 +43,7 @@ class LoginControllerTest {
 
 	@Test
 	@DisplayName("회원가입 요청")
-	public void registerMemberTest() throws Exception {
+	void registerMemberTest() throws Exception {
 		mockMvc.perform(post("/auth/new")
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("email", "test@test.com")
@@ -48,4 +56,41 @@ class LoginControllerTest {
 			.andExpect(redirectedUrl("/auth/login"));
 	}
 
+	@Test
+	@DisplayName("회원가입 요청 - 이메일 중복")
+	void registerMemberWithDuplicateEmailTest() throws Exception {
+		when(memberService.save(any())).thenThrow(new DuplicateEmailException("Duplicate email"));
+
+		mockMvc.perform(post("/auth/new")
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("email", "test@test.com")
+				.param("password", "password123")
+				.param("passwordConfirm", "password123")
+				.param("name", "testUser")
+				.param("role", "FREELANCER"))
+			.andExpect(status().isOk())
+			.andExpect(view().name("new"));
+	}
+
+	@Test
+	@DisplayName("회원가입 요청 - BindingResult 에러")
+	void registerMemberWithBindingResultError() throws Exception {
+		mockMvc.perform(post("/auth/new")
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("email", "test@test.com")
+				.param("password", "")
+				.param("passwordConfirm", "")
+				.param("name", "testUser")
+				.param("role", "FREELANCER"))
+			.andExpect(status().isOk())
+			.andExpect(view().name("new"));
+	}
+
+	@Test
+	@DisplayName("로그인 폼 요청")
+	void loginFormTest() throws Exception {
+		mockMvc.perform(get("/auth/login"))
+			.andExpect(status().isOk())
+			.andExpect(view().name("login"));
+	}
 }

--- a/src/test/java/kr/binarybard/hireo/web/member/controller/MainControllerTest.java
+++ b/src/test/java/kr/binarybard/hireo/web/member/controller/MainControllerTest.java
@@ -1,0 +1,31 @@
+package kr.binarybard.hireo.web.member.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class MainControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("메인 페이지를 성공적으로 불러온다.")
+	void testIndex() throws Exception {
+		mockMvc.perform(get("/"))
+			.andExpect(status().isOk())
+			.andExpect(view().name("index"))
+			.andReturn();
+	}
+}


### PR DESCRIPTION
<!--
PR을 올리기 전에 아래의 항목을 체크해주세요.

1. 작업 내용에 대해 명확하게 설명했는지
2. 새로운 기능/버그 수정 관련된 테스트를 작성했는지
3. 이 PR이 기존 코드에 미치는 영향에 대해 분석했는지
4. 변경 사항이 대단히 크지 않아서 리뷰어가 이해하기 쉬운지
-->

# :dart: PR 주제

- REST API 인증 절차를 위해 새로운 SecurityFilterChain 추가
- 사용자의 ID와 비밀번호를 사용해서 API를 통해 인증할 수 있는 엔드포인트 추가

# :wrench: 변경 유형

- [x] 새로운 기능 (기존 기능과 호환됨)
- [x] 이 변경 내역을 적용하려면 사용자 매뉴얼이나 API 문서를 업데이트해야 함
