### PR TITLE
HIR-26 feat: 모든 요청에 대해 JWT 토큰의 유효성을 검증하는 필터를 구현함

### DIFF
--- a/src/main/java/kr/binarybard/hireo/config/SecurityConfig.java
+++ b/src/main/java/kr/binarybard/hireo/config/SecurityConfig.java
@@ -1,7 +1,5 @@
 package kr.binarybard.hireo.config;
 
-import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.*;
-
 import kr.binarybard.hireo.config.jwt.JwtAccessDeniedHandler;
 import kr.binarybard.hireo.config.jwt.JwtAuthTokenFilter;
 import kr.binarybard.hireo.config.jwt.JwtAuthenticationEntryPoint;
@@ -13,7 +11,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -21,6 +18,8 @@ import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.toH2Console;
 
 @Configuration
 @EnableWebSecurity
@@ -34,12 +33,6 @@ public class SecurityConfig {
 	@Bean
 	public PasswordEncoder passwordEncoder() {
 		return PasswordEncoderFactories.createDelegatingPasswordEncoder();
-	}
-
-	@Bean
-	public WebSecurityCustomizer webSecurityCustomizer() {
-		return web -> web.ignoring()
-			.requestMatchers("/css/**", "/js/**", "/images/**", "/sass/**", "/fonts/**", "/error/**");
 	}
 
 	@Bean
@@ -66,6 +59,7 @@ public class SecurityConfig {
 		return http
 			.csrf(AbstractHttpConfigurer::disable)
 			.authorizeHttpRequests(auth -> auth
+				.requestMatchers("/css/**", "/js/**", "/images/**", "/sass/**", "/fonts/**", "/error/**").permitAll()
 				.requestMatchers(toH2Console()).permitAll()
 				.requestMatchers("/", "/auth/**").permitAll()
 				.anyRequest().authenticated()

--- a/src/main/java/kr/binarybard/hireo/config/SecurityConfig.java
+++ b/src/main/java/kr/binarybard/hireo/config/SecurityConfig.java
@@ -2,6 +2,10 @@ package kr.binarybard.hireo.config;
 
 import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.*;
 
+import kr.binarybard.hireo.config.jwt.JwtAccessDeniedHandler;
+import kr.binarybard.hireo.config.jwt.JwtAuthTokenFilter;
+import kr.binarybard.hireo.config.jwt.JwtAuthenticationEntryPoint;
+import kr.binarybard.hireo.config.jwt.JwtTokenProvider;
 import kr.binarybard.hireo.config.oauth.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -16,12 +20,16 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 	private final CustomOAuth2UserService customOAuth2UserService;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+	private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
 	@Bean
 	public PasswordEncoder passwordEncoder() {
@@ -43,8 +51,12 @@ public class SecurityConfig {
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/api/auth/**").permitAll()
 				.anyRequest().authenticated())
+			.exceptionHandling(handler -> handler
+				.authenticationEntryPoint(jwtAuthenticationEntryPoint)
+				.accessDeniedHandler(jwtAccessDeniedHandler))
 			.sessionManagement(session -> session
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.addFilterBefore(new JwtAuthTokenFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
 			.build();
 	}
 

--- a/src/main/java/kr/binarybard/hireo/config/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/kr/binarybard/hireo/config/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,20 @@
+package kr.binarybard.hireo.config.jwt;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+					   AccessDeniedException accessDeniedException) throws IOException, ServletException {
+		response.sendError(HttpServletResponse.SC_FORBIDDEN, accessDeniedException.getMessage());
+	}
+}

--- a/src/main/java/kr/binarybard/hireo/config/jwt/JwtAuthTokenFilter.java
+++ b/src/main/java/kr/binarybard/hireo/config/jwt/JwtAuthTokenFilter.java
@@ -1,0 +1,56 @@
+package kr.binarybard.hireo.config.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthTokenFilter extends OncePerRequestFilter {
+	private final JwtTokenProvider tokenProvider;
+
+	public static final String AUTHORIZATION_HEADER = "Authorization";
+	public static final String TOKEN_TYPE = "Bearer ";
+
+
+	@Override
+	protected void doFilterInternal(
+		@NotNull HttpServletRequest request,
+		@NotNull HttpServletResponse response,
+		@NotNull FilterChain filterChain
+	) throws ServletException, IOException {
+		final String resolvedToken = resolveToken(request);
+
+		if (StringUtils.hasText(resolvedToken) && tokenProvider.validateToken(resolvedToken)) {
+			Authentication authentication = tokenProvider.getAuthentication(resolvedToken);
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+			log.info("Authenticated user: {}, uri: {}", authentication.getName(), request.getRequestURI());
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	private String resolveToken(HttpServletRequest request) {
+		String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+		if (isValidHeader(bearerToken)) {
+			return bearerToken.substring(7);
+		}
+		return null;
+	}
+
+	private boolean isValidHeader(String header) {
+		return header != null && header.startsWith(TOKEN_TYPE);
+	}
+}

--- a/src/main/java/kr/binarybard/hireo/config/jwt/JwtAuthTokenFilter.java
+++ b/src/main/java/kr/binarybard/hireo/config/jwt/JwtAuthTokenFilter.java
@@ -45,7 +45,7 @@ public class JwtAuthTokenFilter extends OncePerRequestFilter {
 	private String resolveToken(HttpServletRequest request) {
 		String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
 		if (isValidHeader(bearerToken)) {
-			return bearerToken.substring(7);
+			return bearerToken.substring(TOKEN_TYPE.length());
 		}
 		return null;
 	}

--- a/src/main/java/kr/binarybard/hireo/config/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/kr/binarybard/hireo/config/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,22 @@
+package kr.binarybard.hireo.config.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	@Override
+	public void commence(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		AuthenticationException authException
+	) throws IOException {
+		response.sendError(HttpServletResponse.SC_UNAUTHORIZED, authException.getMessage());
+	}
+}

--- a/src/test/java/kr/binarybard/hireo/api/auth/controller/AuthenticationApiControllerTest.java
+++ b/src/test/java/kr/binarybard/hireo/api/auth/controller/AuthenticationApiControllerTest.java
@@ -9,7 +9,6 @@ import kr.binarybard.hireo.api.auth.repository.RefreshTokenRepository;
 import kr.binarybard.hireo.web.auth.dto.SignUpRequest;
 import kr.binarybard.hireo.web.member.repository.MemberRepository;
 import kr.binarybard.hireo.web.member.service.MemberService;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -86,12 +85,12 @@ class AuthenticationApiControllerTest {
 		mockMvc.perform(post("/api/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(status().isForbidden());
+			.andExpect(status().isUnauthorized());
 	}
 
 	@DisplayName("리프레시 토큰이 유효하지 않을 경우 에러를 반환한다.")
 	@Test
-	void testReissueWithInvalidToken() throws Exception {
+	void testReissueWithInvalidToken() {
 		RefreshTokenRequest refreshTokenRequest = RefreshTokenRequest.builder()
 			.refreshToken("invalid-token")
 			.build();
@@ -113,7 +112,7 @@ class AuthenticationApiControllerTest {
 		mockMvc.perform(post("/api/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(signInRequest)))
-			.andExpect(status().isForbidden());
+			.andExpect(status().isUnauthorized());
 	}
 
 	@DisplayName("리프레시 토큰으로 새로운 토큰을 성공적으로 발급한다.")


### PR DESCRIPTION
<!--
PR을 올리기 전에 아래의 항목을 체크해주세요.

1. 작업 내용에 대해 명확하게 설명했는지
2. 새로운 기능/버그 수정 관련된 테스트를 작성했는지
3. 이 PR이 기존 코드에 미치는 영향에 대해 분석했는지
4. 변경 사항이 대단히 크지 않아서 리뷰어가 이해하기 쉬운지
-->

# :dart: PR 주제

- 모든 요청에 대해 JWT 토큰의 유효성을 검증하는 필터를 구현함

# :eyes: 리뷰 포인트

- 모든 요청에 대해 JWT 토큰의 유효성을 검증하는 필터를 구현함
- 인증되지 않은 경우나 인가되지 않은 리소스에 접근하는 경우를 처리하는 핸들러 추가
- 기존에 스프링 시큐리티에서 지적하던 정적 리소스 관련 설정 문제점 수정 (참조 자료 참고)

# :link: 참조 자료

![image](https://github.com/jobflearn/jobflearn/assets/75304316/5d8e9207-43f6-47a0-8849-3eb8d005d37c)

> Spring Security의 이러한 변경 사항은 보안과 관련된 이유들 때문입니다. Spring Security를 통해 구현하는 보안 체인은 다양한 보안 기능들을 제공합니다. 예를 들어, CSRF 보호, Content Security Policy 헤더, X-Content-Type-Options 헤더 등의 중요한 보안 기능들이 이에 포함됩니다.
> 
> web.ignoring()을 사용하면, 이러한 보안 기능들을 우회하게 됩니다. 즉, 이 메소드를 사용하여 특정 경로를 설정하면, 해당 경로로 들어오는 요청은 Spring Security의 보안 필터 체인을 완전히 우회하게 됩니다. 이는 potentionally risky 할 수 있습니다.
> 
> 반면, HttpSecurity.authorizeHttpRequests()를 사용하면, 이러한 요청들도 보안 필터 체인을 통과하게 됩니다. permitAll() 메소드를 사용하면, 특정 경로에 대한 요청은 인증 없이도 접근이 가능하지만, Spring Security의 다른 보안 기능들은 여전히 적용됩니다. 이 방식은 보안에 더욱 유리합니다.

# :wrench: 변경 유형

- [x] 버그 수정 (기존 기능과 호환됨)
- [x] 새로운 기능 (기존 기능과 호환됨)