### PR TITLE
HIR-32 feat: 서버에 파일을 업로드 하는 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    asciidoctorExt
 }
 
 repositories {
@@ -39,6 +40,7 @@ dependencies {
     implementation 'com.h2database:h2'
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 
     compileOnly 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
@@ -58,7 +60,14 @@ tasks.named('test') {
 
 tasks.named('asciidoctor') {
     inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
     dependsOn test
+}
+
+tasks.register('copyDocs', Copy) {
+    dependsOn 'asciidoctor'
+    from "${asciidoctor.outputDir}"
+    into 'src/main/resources/static/api/docs'
 }
 
 jacocoTestReport {

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,105 @@
+= API 가이드
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:sectlinks:
+
+== 인증 API
+
+=== 로그인
+
+사용자는 이메일과 비밀번호를 통해 POST 요청을 `/api/auth/login` 엔드포인트로 보내어 로그인할 수 있습니다.
+
+[source,http]
+----
+POST /api/auth/login
+----
+
+include::{snippets}/login/curl-request.adoc[]
+==== HTTP 요청
+
+include::{snippets}/login/http-request.adoc[]
+
+include::{snippets}/login/request-fields.adoc[]
+
+==== HTTP 응답
+
+include::{snippets}/login/http-response.adoc[]
+
+=== 토큰 재발급
+
+사용자는 POST 요청을 `/api/auth/reissue` 엔드포인트로 보내어 refresh token을 이용하여 새로운 access token을 받을 수 있습니다.
+
+[source,http]
+----
+POST /api/auth/reissue
+----
+
+include::{snippets}/reissue-token/curl-request.adoc[]
+==== HTTP 요청
+
+include::{snippets}/reissue-token/http-request.adoc[]
+
+include::{snippets}/reissue-token/request-fields.adoc[]
+
+==== HTTP 응답
+
+include::{snippets}/reissue-token/http-response.adoc[]
+
+== 파일 API
+
+=== 파일 업로드
+
+사용자는 POST 요청을 `/api/files/upload` 또는 `/files/upload` 엔드포인트로 보내어 파일을 업로드할 수 있습니다.
+
+[source,http]
+----
+POST /api/files/upload
+----
+
+include::{snippets}/upload-file/curl-request.adoc[]
+==== HTTP 요청
+
+include::{snippets}/upload-file/http-request.adoc[]
+
+==== HTTP 응답
+
+include::{snippets}/upload-file/http-response.adoc[]
+
+=== 해시로 파일 업로드
+
+사용자는 POST 요청을 `/api/files/upload/hash` 또는 `/files/upload/hash` 엔드포인트로 보내어 해시를 이용하여 파일을 업로드할 수 있습니다.
+
+[source,http]
+----
+POST /api/files/upload/hash
+----
+
+include::{snippets}/upload-file-hash/curl-request.adoc[]
+==== HTTP 요청
+
+include::{snippets}/upload-file-hash/http-request.adoc[]
+
+==== HTTP 응답
+
+include::{snippets}/upload-file-hash/http-response.adoc[]
+
+=== 파일 로드
+
+사용자는 GET 요청을 `/api/files/load/{fileName}` 또는 `/files/load/{fileName}` 엔드포인트로 보내어 특정 파일을 로드할 수 있습니다.
+
+[source,http]
+----
+GET /api/files/load/{fileName}
+----
+
+include::{snippets}/load-file/curl-request.adoc[]
+==== HTTP 요청
+
+include::{snippets}/load-file/http-request.adoc[]
+
+==== HTTP 응답
+
+include::{snippets}/load-file/http-response.adoc[]

--- a/src/main/java/kr/binarybard/hireo/api/file/controller/FileApiController.java
+++ b/src/main/java/kr/binarybard/hireo/api/file/controller/FileApiController.java
@@ -1,0 +1,35 @@
+package kr.binarybard.hireo.api.file.controller;
+
+import kr.binarybard.hireo.api.file.dto.FileResponse;
+import kr.binarybard.hireo.api.file.service.FileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+public class FileApiController {
+
+	private final FileService fileService;
+
+	@PostMapping({"/api/files/upload", "/files/upload"})
+	public ResponseEntity<FileResponse> uploadFile(MultipartFile file) {
+		return ResponseEntity.ok().body(fileService.store(file));
+	}
+
+	@PostMapping({"/api/files/upload/hash", "/files/upload/hash"})
+	public ResponseEntity<FileResponse> uploadFileAsHash(MultipartFile file) {
+		return ResponseEntity.ok().body(fileService.storeAsHash(file));
+	}
+
+	@GetMapping({"/api/files/load/{fileName}", "/files/load/{fileName}"})
+	public ResponseEntity<Resource> loadFile(@PathVariable String fileName) {
+		var resource = fileService.load(fileName);
+		return ResponseEntity.ok()
+			.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + resource.getFilename() + "\"")
+			.body(resource);
+	}
+}

--- a/src/main/java/kr/binarybard/hireo/api/file/dto/FileResponse.java
+++ b/src/main/java/kr/binarybard/hireo/api/file/dto/FileResponse.java
@@ -1,0 +1,22 @@
+package kr.binarybard.hireo.api.file.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class FileResponse {
+	private String fileName;
+	private long fileSize;
+	private String contentType;
+	private LocalDateTime uploadTimestamp;
+
+	@Builder
+	public FileResponse(String fileName, long fileSize, String contentType, LocalDateTime uploadTimestamp) {
+		this.fileName = fileName;
+		this.fileSize = fileSize;
+		this.contentType = contentType;
+		this.uploadTimestamp = uploadTimestamp;
+	}
+}

--- a/src/main/java/kr/binarybard/hireo/api/file/service/FileService.java
+++ b/src/main/java/kr/binarybard/hireo/api/file/service/FileService.java
@@ -1,0 +1,120 @@
+package kr.binarybard.hireo.api.file.service;
+
+import kr.binarybard.hireo.api.file.dto.FileResponse;
+import kr.binarybard.hireo.common.exceptions.ErrorCode;
+import kr.binarybard.hireo.common.exceptions.FileProcessingException;
+import kr.binarybard.hireo.common.exceptions.InvalidValueException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+
+@Service
+public class FileService {
+	private final Path root;
+
+	public FileService(@Value("${file.upload-dir}") String uploadDir) {
+		this.root = Paths.get(uploadDir);
+		try {
+			Files.createDirectories(root);
+		} catch (IOException ex) {
+			throw new FileProcessingException(ErrorCode.FILE_STORAGE_FAILED, "디렉토리 생성 실패: " + root);
+		}
+	}
+
+	public FileResponse store(MultipartFile file) {
+		String fileName = validateFileName(file.getOriginalFilename());
+		validateFileSize(file.getSize());
+		Path filePath = saveFile(file, fileName);
+		return buildFileResponse(filePath, file.getSize(), file.getContentType());
+	}
+
+
+	public FileResponse storeAsHash(MultipartFile file) {
+		try {
+			validateFileSize(file.getSize());
+			byte[] fileBytes = file.getBytes();
+			String hashedName = hashFile(fileBytes);
+			Path filePath = saveFile(file, hashedName);
+			return buildFileResponse(filePath, file.getSize(), file.getContentType());
+		} catch (IOException ex) {
+			throw new FileProcessingException(ErrorCode.FILE_STORAGE_FAILED, "파일명: " + file.getOriginalFilename());
+		}
+	}
+
+	private FileResponse buildFileResponse(Path filePath, long fileSize, String contentType) {
+		return FileResponse.builder()
+			.fileName(filePath.getFileName().toString())
+			.fileSize(fileSize)
+			.contentType(contentType)
+			.uploadTimestamp(LocalDateTime.now())
+			.build();
+	}
+
+	private Path saveFile(MultipartFile file, String fileName) {
+		Path targetLocation = root.resolve(fileName);
+		try {
+			Files.copy(file.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
+		} catch (IOException ex) {
+			throw new FileProcessingException(ErrorCode.FILE_UPLOAD_FAILED, "파일명: " + fileName);
+		}
+		return targetLocation;
+	}
+
+	public Resource load(String fileName) {
+		Path filePath = root.resolve(fileName);
+		Resource resource;
+		try {
+			resource = new UrlResource(filePath.toUri());
+			if (resource.exists() || resource.isReadable()) {
+				return resource;
+			}
+			throw new FileProcessingException(ErrorCode.FILE_NOT_FOUND, "파일명: " + fileName);
+		} catch (MalformedURLException ex) {
+			throw new FileProcessingException(ErrorCode.FILE_NOT_FOUND, "파일명: " + fileName);
+		}
+	}
+
+	private String validateFileName(String originalFilename) {
+		if (originalFilename == null || originalFilename.isEmpty()) {
+			throw new InvalidValueException(ErrorCode.INVALID_INPUT_VALUE, "파일 이름이 유효하지 않음");
+		}
+		return StringUtils.cleanPath(originalFilename);
+	}
+
+	private void validateFileSize(long fileSize) {
+		if (fileSize == 0) {
+			throw new FileProcessingException(ErrorCode.FILE_SIZE_ZERO);
+		}
+	}
+
+	private String hashFile(byte[] fileData) {
+		try {
+			MessageDigest md = MessageDigest.getInstance("SHA-256");
+			byte[] hashedBytes = md.digest(fileData);
+			return bytesToHex(hashedBytes);
+		} catch (NoSuchAlgorithmException e) {
+			throw new FileProcessingException(ErrorCode.FILE_HASHING_FAILED);
+		}
+	}
+
+	private String bytesToHex(byte[] bytes) {
+		StringBuilder sb = new StringBuilder(2 * bytes.length);
+		for (byte b : bytes) {
+			sb.append(String.format("%02x", b));
+		}
+		return sb.toString();
+	}
+}

--- a/src/main/java/kr/binarybard/hireo/common/exceptions/ErrorCode.java
+++ b/src/main/java/kr/binarybard/hireo/common/exceptions/ErrorCode.java
@@ -22,6 +22,14 @@ public enum ErrorCode {
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A_001", "유효하지 않은 토큰입니다."),
 	UNSUPPORTED_OAUTH2_PROVIDER(HttpStatus.BAD_REQUEST, "A_002", "지원하지 않는 OAuth2 프로바이더입니다."),
 
+	FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F_001", "파일 업로드 중 오류가 발생하였습니다."),
+	FILE_HASHING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F_002", "파일 해싱 중 오류가 발생하였습니다."),
+	FILE_READING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F_003", "파일 읽기 중 오류가 발생하였습니다."),
+	FILE_STORAGE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F_004", "파일 저장 중 오류가 발생하였습니다."),
+	FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "F_005", "파일을 찾을 수 없습니다."),
+	FILE_SIZE_TOO_LARGE(HttpStatus.BAD_REQUEST, "F_006", "파일 크기가 너무 큽니다."),
+	FILE_SIZE_ZERO(HttpStatus.BAD_REQUEST, "F_007", "파일 크기가 0입니다."),
+
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S_001", "서버에 오류가 발생하였습니다."),
 	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "S_002", "잘못된 요청 값입니다."),
 	TOKEN_HASHING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S_003", "토큰 해싱 중 오류가 발생하였습니다.");

--- a/src/main/java/kr/binarybard/hireo/common/exceptions/FileProcessingException.java
+++ b/src/main/java/kr/binarybard/hireo/common/exceptions/FileProcessingException.java
@@ -1,0 +1,12 @@
+package kr.binarybard.hireo.common.exceptions;
+
+public class FileProcessingException extends BusinessException {
+
+	public FileProcessingException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+
+	public FileProcessingException(ErrorCode errorCode, String detail) {
+		super(errorCode, detail);
+	}
+}

--- a/src/main/java/kr/binarybard/hireo/config/SecurityConfig.java
+++ b/src/main/java/kr/binarybard/hireo/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
 			.securityMatcher("/api/**")
 			.csrf(AbstractHttpConfigurer::disable)
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers("/api/auth/**").permitAll()
+				.requestMatchers("/api/auth/**", "/api/docs/**").permitAll()
 				.anyRequest().authenticated())
 			.exceptionHandling(handler -> handler
 				.authenticationEntryPoint(jwtAuthenticationEntryPoint)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,3 +56,5 @@ security:
     refresh-expiration-time: 604800000
     base64-secret: ENC(pMCfBtvxA+VV4S6cDjAokWd0z0Qr883sMgCOEB6fjeJbL84smdB9NnUj+NO2SiTqBUoM4LPjbw15Yxv+3tg0uBHHmH7X0E9JGtUmIhHoXEwQxc/Izw30z99On6j/DalJ5XSfSTdERxs=)
 
+file:
+    upload-dir: D:\Images

--- a/src/test/java/kr/binarybard/hireo/api/docs/AuthenticationApiControllerTest.java
+++ b/src/test/java/kr/binarybard/hireo/api/docs/AuthenticationApiControllerTest.java
@@ -1,0 +1,124 @@
+package kr.binarybard.hireo.api.docs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.binarybard.hireo.api.auth.dto.RefreshTokenRequest;
+import kr.binarybard.hireo.api.auth.dto.SignInRequest;
+import kr.binarybard.hireo.api.auth.service.RefreshTokenService;
+import kr.binarybard.hireo.config.jwt.JwtTokenProvider;
+import kr.binarybard.hireo.web.auth.dto.SignUpRequest;
+import kr.binarybard.hireo.web.auth.service.LoginService;
+import kr.binarybard.hireo.web.member.service.MemberService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class AuthenticationApiControllerTest extends RestDocsConfiguration {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private LoginService loginService;
+
+	@MockBean
+	private JwtTokenProvider jwtTokenProvider;
+
+	@MockBean
+	private AuthenticationManagerBuilder authenticationManagerBuilder;
+
+	@Mock
+	private AuthenticationManager authenticationManager;
+
+	@MockBean
+	private RefreshTokenService refreshTokenService;
+
+	private final String username = "test@example.com";
+	private final String password = "password1234";
+
+	@BeforeEach
+	void setup() {
+		when(jwtTokenProvider.createAccessToken(any())).thenReturn("valid-access-token");
+		when(jwtTokenProvider.createRefreshToken(any())).thenReturn("valid-refresh-token");
+		when(refreshTokenService.validateToken(anyString())).thenReturn(true);
+		when(jwtTokenProvider.getUsernameFromToken(anyString())).thenReturn(username);
+		when(loginService.loadUserByUsername(anyString())).thenReturn(new User(username, password, new ArrayList<>()));
+
+		when(authenticationManagerBuilder.getObject()).thenReturn(authenticationManager);
+	}
+
+	@Test
+	@DisplayName("로그인 성공")
+	void loginSuccess() throws Exception {
+		// Arrange
+		SignInRequest signInRequest = SignInRequest.builder()
+			.email(username)
+			.password(password)
+			.build();
+
+		// Act & Assert
+		mockMvc.perform(post("/api/auth/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(signInRequest)))
+			.andExpect(status().isOk())
+			.andDo(document("login",
+				requestFields(
+					fieldWithPath("email").description("로그인 이메일"),
+					fieldWithPath("password").description("로그인 비밀번호")
+				),
+				responseFields(
+					fieldWithPath("access_token").description("액세스 토큰"),
+					fieldWithPath("refresh_token").description("리프레시 토큰")
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("토큰 재발급 성공")
+	void reissueTokenSuccess() throws Exception {
+		// Arrange
+		RefreshTokenRequest refreshTokenRequest = RefreshTokenRequest.builder()
+			.refreshToken("refresh_token")
+			.build();
+
+		// Act & Assert
+		mockMvc.perform(post("/api/auth/reissue")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(refreshTokenRequest)))
+			.andExpect(status().isOk())
+			.andDo(document("reissue-token",
+				requestFields(
+					fieldWithPath("refresh_token").description("재발급 요청 토큰")
+				),
+				responseFields(
+					fieldWithPath("access_token").description("액세스 토큰"),
+					fieldWithPath("refresh_token").description("리프레시 토큰")
+				)
+			));
+	}
+}

--- a/src/test/java/kr/binarybard/hireo/api/docs/FileApiControllerTest.java
+++ b/src/test/java/kr/binarybard/hireo/api/docs/FileApiControllerTest.java
@@ -1,0 +1,116 @@
+package kr.binarybard.hireo.api.docs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.binarybard.hireo.api.file.dto.FileResponse;
+import kr.binarybard.hireo.api.file.service.FileService;
+import kr.binarybard.hireo.web.fixture.MemberFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WithMockUser(username = MemberFixture.TEST_EMAIL)
+class FileApiControllerTest extends RestDocsConfiguration {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private FileService fileService;
+
+	@Mock
+	private MultipartFile file;
+
+	@BeforeEach
+	void setup() {
+		LocalDateTime now = LocalDateTime.now();
+		Resource mockResource = mock(Resource.class);
+
+		when(fileService.store(any())).thenReturn(new FileResponse("testFile.jpg", 12345, "image/jpeg", now));
+		when(fileService.storeAsHash(any())).thenReturn(new FileResponse("hashedTestFile.jpg", 12345, "image/jpeg", now));
+		when(fileService.load(anyString())).thenReturn(mockResource);
+		when(mockResource.getFilename()).thenReturn("testFile.jpg");
+	}
+
+	@Test
+	@DisplayName("파일 업로드 성공")
+	void uploadFileSuccess() throws Exception {
+		// Act & Assert
+		mockMvc.perform(multipart("/api/files/upload")
+				.file("file", "testFileContent".getBytes())
+				.contentType(MediaType.MULTIPART_FORM_DATA))
+			.andExpect(status().isOk())
+			.andDo(document("upload-file",
+				requestParts(
+					partWithName("file").description("업로드 파일")
+				),
+				responseFields(
+					fieldWithPath("fileName").description("파일 이름"),
+					fieldWithPath("fileSize").description("파일 크기"),
+					fieldWithPath("contentType").description("파일 유형"),
+					fieldWithPath("uploadTimestamp").description("파일 업로드 시간")
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("해시를 이용한 파일 업로드 성공")
+	void uploadFileAsHashSuccess() throws Exception {
+		// Act & Assert
+		mockMvc.perform(multipart("/api/files/upload/hash")
+				.file("file", "testFileContent".getBytes())
+				.contentType(MediaType.MULTIPART_FORM_DATA))
+			.andExpect(status().isOk())
+			.andDo(document("upload-file-hash",
+				requestParts(
+					partWithName("file").description("업로드 파일")
+				),
+				responseFields(
+					fieldWithPath("fileName").description("파일 이름"),
+					fieldWithPath("fileSize").description("파일 크기"),
+					fieldWithPath("contentType").description("파일 유형"),
+					fieldWithPath("uploadTimestamp").description("파일 업로드 시간")
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("파일 로드 성공")
+	void loadFileSuccess() throws Exception {
+		// Act & Assert
+		mockMvc.perform(get("/api/files/load/testFile.jpg")
+				.accept(MediaType.APPLICATION_OCTET_STREAM))
+			.andExpect(status().isOk())
+			.andDo(document("load-file",
+				responseHeaders(
+					headerWithName("Content-Disposition").description("파일 이름 헤더")
+				)
+			));
+	}
+}

--- a/src/test/java/kr/binarybard/hireo/api/docs/RestDocsConfiguration.java
+++ b/src/test/java/kr/binarybard/hireo/api/docs/RestDocsConfiguration.java
@@ -1,0 +1,11 @@
+package kr.binarybard.hireo.api.docs;
+
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs(uriHost = "jobflearn.binarybard.kr", uriPort = 443, uriScheme = "https")
+public class RestDocsConfiguration {
+}

--- a/src/test/java/kr/binarybard/hireo/api/file/controller/FileApiControllerTest.java
+++ b/src/test/java/kr/binarybard/hireo/api/file/controller/FileApiControllerTest.java
@@ -1,0 +1,95 @@
+package kr.binarybard.hireo.api.file.controller;
+
+import kr.binarybard.hireo.api.file.dto.FileResponse;
+import kr.binarybard.hireo.api.file.service.FileService;
+import kr.binarybard.hireo.common.AcceptanceTest;
+import kr.binarybard.hireo.web.fixture.MemberFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WithMockUser(username = MemberFixture.TEST_EMAIL)
+class FileApiControllerTest extends AcceptanceTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private FileService fileService;
+
+	@Test
+	@DisplayName("일반 파일 업로드 요청이 성공적으로 처리되어야 한다.")
+	void testUploadFile() throws Exception {
+		// given
+		MockMultipartFile file = new MockMultipartFile("file", "filename.txt",
+			"text/plain", "some content".getBytes());
+		FileResponse mockResponse = FileResponse.builder()
+			.fileName("filename.txt")
+			.fileSize(file.getSize())
+			.contentType(file.getContentType())
+			.uploadTimestamp(LocalDateTime.now())
+			.build();
+
+		when(fileService.store(any(MultipartFile.class))).thenReturn(mockResponse);
+
+		// expected
+		mockMvc.perform(multipart("/api/files/upload")
+				.file(file))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.fileName", is("filename.txt")));
+	}
+
+	@Test
+	@DisplayName("해시 파일명으로 파일 업로드 요청이 성공적으로 처리되어야 한다.")
+	void testUploadFileAsHash() throws Exception {
+		// given
+		MockMultipartFile file = new MockMultipartFile("file", "filename.txt",
+			"text/plain", "some content".getBytes());
+		FileResponse mockResponse = FileResponse.builder()
+			.fileName("hashedfilename.txt")
+			.fileSize(file.getSize())
+			.contentType(file.getContentType())
+			.uploadTimestamp(LocalDateTime.now())
+			.build();
+
+		when(fileService.storeAsHash(any(MultipartFile.class))).thenReturn(mockResponse);
+
+		// expected
+		mockMvc.perform(multipart("/api/files/upload/hash")
+				.file(file))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.fileName", is("hashedfilename.txt")));
+	}
+
+	@Test
+	@DisplayName("주어진 파일명으로 파일 로드 요청이 성공적으로 처리되어야 한다.")
+	void testLoadFile() throws Exception {
+		// given
+		String fileName = "testfile.txt";
+		Resource resource = new ByteArrayResource("testfile content".getBytes());
+
+		when(fileService.load(anyString())).thenReturn(resource);
+
+		// expected
+		mockMvc.perform(get("/api/files/load/" + fileName))
+			.andExpect(status().isOk());
+	}
+}

--- a/src/test/java/kr/binarybard/hireo/api/file/service/FileServiceTest.java
+++ b/src/test/java/kr/binarybard/hireo/api/file/service/FileServiceTest.java
@@ -1,0 +1,135 @@
+package kr.binarybard.hireo.api.file.service;
+
+import kr.binarybard.hireo.api.file.dto.FileResponse;
+import kr.binarybard.hireo.common.exceptions.FileProcessingException;
+import kr.binarybard.hireo.common.exceptions.InvalidValueException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.Resource;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FileServiceTest {
+
+	private FileService fileService;
+
+	@Mock
+	private MultipartFile file;
+
+	@TempDir
+	Path tempDir;
+
+	@BeforeEach
+	void setUp() {
+		fileService = new FileService(tempDir.toString());
+	}
+
+	@Test
+	@DisplayName("파일 업로드는 정상적으로 처리되어야 한다.")
+	void testStoreFile() throws IOException {
+		// given
+		String originalFilename = "testFile.txt";
+		String contentType = "text/plain";
+		long fileSize = 20L;
+
+		when(file.getOriginalFilename()).thenReturn(originalFilename);
+		when(file.getContentType()).thenReturn(contentType);
+		when(file.getSize()).thenReturn(fileSize);
+		when(file.getInputStream()).thenReturn(new ByteArrayInputStream("test content".getBytes()));
+
+		// when
+		FileResponse response = fileService.store(file);
+
+		// then
+		assertThat(response.getFileName()).isEqualTo(originalFilename);
+		assertThat(response.getFileSize()).isEqualTo(fileSize);
+		assertThat(response.getContentType()).isEqualTo(contentType);
+	}
+
+	@Test
+	@DisplayName("파일 해시명으로 업로드는 정상적으로 처리되어야 한다.")
+	void testStoreFileAsHash() throws IOException {
+		// given
+		String originalFilename = "testFile.txt";
+		String contentType = "text/plain";
+		long fileSize = 20L;
+
+		when(file.getContentType()).thenReturn(contentType);
+		when(file.getSize()).thenReturn(fileSize);
+		when(file.getBytes()).thenReturn("test content".getBytes());
+		when(file.getInputStream()).thenReturn(new ByteArrayInputStream("test content".getBytes()));
+
+		// when
+		FileResponse response = fileService.storeAsHash(file);
+
+		// then
+		assertThat(response.getFileName()).isNotEqualTo(originalFilename);
+		assertThat(response.getFileSize()).isEqualTo(fileSize);
+		assertThat(response.getContentType()).isEqualTo(contentType);
+	}
+
+	@Test
+	@DisplayName("파일 로드는 정상적으로 처리되어야 한다.")
+	void testLoadFile() throws IOException {
+		// given
+		String fileName = "testfile.txt";
+
+		Files.createFile(tempDir.resolve(fileName));
+
+		// when
+		Resource resource = fileService.load(fileName);
+
+		// then
+		assertThat(resource).isNotNull();
+	}
+
+	@Test
+	@DisplayName("파일 이름이 유효하지 않을 때 예외를 발생시켜야 한다.")
+	void testStoreFileInvalidName() {
+		// given
+		when(file.getOriginalFilename()).thenReturn(null);
+
+		// expected
+		assertThatThrownBy(() -> fileService.store(file))
+			.isInstanceOf(InvalidValueException.class);
+	}
+
+	@Test
+	@DisplayName("파일이 없을 때 로드 시도하면 예외가 발생해야 한다.")
+	void testLoadFileNotFound() {
+		// expected
+		String nonExistingFileName = "nonExistingFile.txt";
+
+		assertThatThrownBy(() -> fileService.load(nonExistingFileName))
+			.isInstanceOf(FileProcessingException.class);
+	}
+
+	@Test
+	@DisplayName("파일 크기가 0인 경우 예외가 발생해야 한다.")
+	void testStoreFileWithZeroSize() {
+		// given
+		String originalFilename = "emptyFile.txt";
+
+		when(file.getOriginalFilename()).thenReturn(originalFilename);
+		when(file.getSize()).thenReturn(0L);
+
+		// expected
+		assertThatThrownBy(() -> fileService.store(file))
+			.isInstanceOf(FileProcessingException.class);
+	}
+}
+


### PR DESCRIPTION
<!--
PR을 올리기 전에 아래의 항목을 체크해주세요.

1. 작업 내용에 대해 명확하게 설명했는지
2. 새로운 기능/버그 수정 관련된 테스트를 작성했는지
3. 이 PR이 기존 코드에 미치는 영향에 대해 분석했는지
4. 변경 사항이 대단히 크지 않아서 리뷰어가 이해하기 쉬운지
-->

# :dart: PR 주제

사용자는 서버에 파일을 업로드할 수 있다.

# :eyes: 리뷰 포인트

- 파일 처리 중 발생하는 예외 클래스와 처리 상태를 나타내는 다양한 에러 코드 추가
- 파일을 저장하거나 서빙하는 엔드포인트 제공

# :wrench: 변경 유형

- [x] 새로운 기능 (기존 기능과 호환됨)
- [x] 이 변경 내역을 적용하려면 사용자 매뉴얼이나 API 문서를 업데이트해야 함