### PR TITLE
build: dependabot 설정 추가

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gradle" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    labels:
+      - "🔗 dependencies"


### PR DESCRIPTION
<!--
PR을 올리기 전에 아래의 항목을 체크해주세요.

1. 작업 내용에 대해 명확하게 설명했는지
2. 새로운 기능/버그 수정 관련된 테스트를 작성했는지
3. 이 PR이 기존 코드에 미치는 영향에 대해 분석했는지
4. 변경 사항이 대단히 크지 않아서 리뷰어가 이해하기 쉬운지
-->

# :dart: PR 주제

- Dependabot 설정을 추가하여 프로젝트의 종속성을 자동으로 관리한다.

# :eyes: 리뷰 포인트

![image](https://github.com/jobflearn/jobflearn/assets/75304316/77d87a22-fbc3-4772-bfb9-70c0f21156ac)

- `package-ecosystem`: 우리의 프로젝트가 Gradle을 사용하므로 "gradle"로 설정하였습니다.
- `directory`: 종속성 명세가 있는 디렉토리를 나타냅니다. 대부분의 경우 프로젝트의 루트 디렉토리에 build.gradle 파일이 위치하므로, 이를 "/"로 설정하였습니다.
- `schedule.interval`: 이 설정은 Dependabot이 얼마나 자주 프로젝트를 스캔할지를 결정합니다. "daily"로 설정하였으므로, Dependabot은 매일 종속성을 검사하게 됩니다.

이 설정이 우리의 프로젝트에 적합한지, 또는 다른 설정이 필요한 부분이 있는지 확인해 주시면 감사하겠습니다.

# :link: 참조 자료

- https://dev-yakuza.posstree.com/ko/flutter/github/dependabot/
- https://github.com/woowacourse-teams/2020-6rinkers/pulls